### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ryanpfalz/c4fe1222-02e3-4847-896b-9152cd9066c9/0fa69a15-2340-4d9b-bbd2-0cdd9f438ab5/_apis/work/boardbadge/fcaeefee-37b2-41ce-a4ee-6322358600f9)](https://dev.azure.com/ryanpfalz/c4fe1222-02e3-4847-896b-9152cd9066c9/_boards/board/t/0fa69a15-2340-4d9b-bbd2-0cdd9f438ab5/Microsoft.RequirementCategory)
 # azure-devops-github-intro
 
 ---


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#18](https://dev.azure.com/ryanpfalz/c4fe1222-02e3-4847-896b-9152cd9066c9/_workitems/edit/18). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.